### PR TITLE
fix(revert): Use old tag trigger

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,10 +1,8 @@
+name: Auto Release 🤖🦾🚀
 on:
   push:
-    # https://docs.github.com/en/webhooks-and-events/events/github-event-types#event-payload-object-for-pushevent
-    # https://stackoverflow.com/a/69919067
-    # branches: [main]
     tags:
-      - v*.*.*
+      - "v*"
 
 env:
   NODE_VERSION: 18


### PR DESCRIPTION
Getting the Github Workflow triggers with tags is turning out to be extremely complicated