### PR TITLE
ci(trigger): Copy version trigger from other repo

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Auto Release 🤖🦾🚀
 on:
   push:
     tags:
-      - "v*"
+      - "v**"
 
 env:
   NODE_VERSION: 18


### PR DESCRIPTION
This trigger still seems to be causing problems.

Copying this trigger from my other repo: [`"v**"`](https://github.com/aaronclong/barcode-detector-polyfill/blob/3cc383ed926a7fd9eb3d363fef95f8f78be0be8b/.github/workflows/auto-release.yml#L6-L7)